### PR TITLE
Avoid using undefined THIS_SCRIPT which throws PHP7 warnings

### DIFF
--- a/Upload/inc/plugins/ougc_adminpostedit.php
+++ b/Upload/inc/plugins/ougc_adminpostedit.php
@@ -34,7 +34,7 @@ defined('IN_MYBB') or die('Direct initialization of this file is not allowed.');
 defined('PLUGINLIBRARY') or define('PLUGINLIBRARY', MYBB_ROOT.'inc/plugins/pluginlibrary.php');
 
 // Cache template
-if(THIS_SCRIPT == 'editpost.php')
+if(defined('THIS_SCRIPT') && THIS_SCRIPT == 'editpost.php')
 {
 	global $templatelist;
 


### PR DESCRIPTION
Warning example:
```
<error>
	<dateline>1571476004</dateline>
	<script>inc/plugins/ougc_adminpostedit.php</script>
	<line>37</line>
	<type>2</type>
	<friendly_type>Warning</friendly_type>
	<message>Use of undefined constant THIS_SCRIPT - assumed 'THIS_SCRIPT' (this will throw an Error in a future version of PHP)</message>
</error>
```